### PR TITLE
Update zapret-hosts-user-exclude.txt

### DIFF
--- a/zapret-hosts-user-exclude.txt
+++ b/zapret-hosts-user-exclude.txt
@@ -1,3 +1,4 @@
+miui.com
 gov.ru
 nalog.ru
 sudrf.ru


### PR DESCRIPTION
Добавить "miui.com" в исключения, иначе апдейты оболочки не приходят. Ну и возможно ещё что-то из сервисов xiaomi починится, о чем я не знаю.