### PR TITLE
Добавление honkaiimpact3.com (HoYoverse) в список исключений

### DIFF
--- a/zapret-hosts-user-exclude.txt
+++ b/zapret-hosts-user-exclude.txt
@@ -191,6 +191,7 @@ yuanshen.com
 hoyoverse.com
 genshinimpact.com
 zenlesszonezero.com
+honkaiimpact3.com
 #################################### Xiaomi
 mi.com
 miui.com


### PR DESCRIPTION
Невозможно зайти в игру Honkai Impact 3rd, если этот домен не в исключениях