### PR TITLE
Добавить GeoHide hosts + Xbox DNS для OpenAI

### DIFF
--- a/Zapret-Manager.sh
+++ b/Zapret-Manager.sh
@@ -15,6 +15,7 @@ GREEN="\033[1;32m"; RED="\033[1;31m"; CYAN="\033[1;36m"; YELLOW="\033[1;33m"; MA
 CONF="/etc/config/zapret"; CUSTOM_DIR="/opt/zapret/init.d/openwrt/custom.d/"; HOSTLIST_FILE="/opt/zapret/ipset/zapret-hosts-user.txt"; fileGP="/opt/zapret/ipset/zapret-hosts-google.txt"
 STR_URL="https://raw.githubusercontent.com/StressOzz/Zapret-Manager/refs/heads/main/files/ListStrYou"
 GEO_HOSTS="https://raw.githubusercontent.com/Internet-Helper/GeoHideDNS/refs/heads/main/hosts/hosts"
+XBOX_DNS_SERVERS="111.88.96.50 111.88.96.51"; XBOX_DNS_DOMAINS="chatgpt.com/openai.com/oaistatic.com/oaiusercontent.com/openaimerge.com/sora.com/cdn.auth0.com"
 TMP_SF="/tmp/zapret_temp"; HOSTS_FILE="/etc/hosts"; TMP_LIST="$TMP_SF/zapret_yt_list.txt"; tmpDIR="/tmp/PodkopAWG"
 IF_NAME="AWG"; PROTO="amneziawg"; DEV_NAME="amneziawg0"; BASE_URL="https://github.com/Slava-Shchipunov/awg-openwrt/releases/download/"
 SAVED_STR="$TMP_SF/StrYou.txt"; HOSTS_USER="$TMP_SF/hosts-user.txt"; OUT_DPI="$TMP_SF/dpi_urls.txt"; OUT="$TMP_SF/str_flow.txt"; ZIP="$TMP_SF/repo.zip"
@@ -71,7 +72,8 @@ GITH_RAW="#githubusercontent.com\n185.199.109.133 raw.githubusercontent.com rele
 185.199.108.133 private-user-images.githubusercontent.com gist.githubusercontent.com avatars.githubusercontent.com"
 GITH="#github.com\n140.82.114.3 github.com\n185.199.110.154 github.githubassets.com\n185.199.110.133 camo.githubassets.com"
 ALL_BLOCKS="$AI\n$INSTAGRAM\n$NTC\n$RUTOR\n$LIBRUSEC\n$TGWeb\n$TWCH\n$SCell\n$SPFY\n$GITH_RAW"; TMP_ARCHIVE_RS="/tmp/tg-ws-proxy-rs.tar.gz"; TMP_DIR_RS="/tmp/tg-ws-proxy-rs"
-hosts_enabled() { if grep -q "### dns.malw.link" /etc/hosts; then hosts_echo="Malw.link"; return 0; elif grep -q "#mafioznik" /etc/hosts; then hosts_echo="Mafioznik"; return 0; elif grep -q "### dns.geohide.ru" /etc/hosts; then hosts_echo="GeoHide"; return 0
+xbox_dns_enabled() { local DNSMASQ_SERVERS SERVER; DNSMASQ_SERVERS=" $(uci -q get dhcp.@dnsmasq[0].server) "; for SERVER in $XBOX_DNS_SERVERS; do case "$DNSMASQ_SERVERS" in *" /$XBOX_DNS_DOMAINS/$SERVER "*) ;; *) return 1;; esac; done; return 0; }
+hosts_enabled() { if grep -q "### dns.malw.link" /etc/hosts; then hosts_echo="Malw.link"; return 0; elif grep -q "#mafioznik" /etc/hosts; then hosts_echo="Mafioznik"; return 0; elif grep -q "### dns.geohide.ru" /etc/hosts; then xbox_dns_enabled && hosts_echo="GeoHide hosts + Xbox DNS для OpenAI" || hosts_echo="GeoHide"; return 0
 elif grep -q "45.155.204.190\|instagram.com\|rutor.info\|lib.rus.ec\|ntc.party\|twitch.tv\|web.telegram.org\|www.spotify.com\|store.supercell.com\|raw.githubusercontent.com\|lkfl2.nalog.ru" /etc/hosts; then hosts_echo="добавлены"; return 0; fi; return 1; }
 hosts_add() { printf "%b\n" "$1" | while IFS= read -r L; do grep -qxF "$L" /etc/hosts || echo "$L" >> /etc/hosts; done; /etc/init.d/dnsmasq restart >/dev/null 2>&1; }
 ZAPRET_RESTART () { chmod +x /opt/zapret/sync_config.sh; /opt/zapret/sync_config.sh; /etc/init.d/zapret restart >/dev/null 2>&1; sleep 1; }
@@ -425,10 +427,15 @@ echo -e "\n${MAGENTA}Включаем IPv6 в Zapret${NC}"; ZAPRET_RESTART; echo
 # ==========================================
 # Hosts menu
 # ==========================================
-hosts_reset() { echo -e "\n${MAGENTA}Восстанавливаем hosts${NC}"; : > /etc/hosts; echo -e "127.0.0.1\tlocalhost\n\n::1\tlocalhost ip6-localhost ip6-loopback\nff02::1 ip6-allnodes\nff02::2 ip6-allrouters" > /etc/hosts; /etc/init.d/dnsmasq restart >/dev/null 2>&1; echo -e "hosts ${GREEN}восстановлен!${NC}\n"; PAUSE; }
+write_default_hosts() { printf "127.0.0.1\tlocalhost\n\n::1\tlocalhost ip6-localhost ip6-loopback\nff02::1 ip6-allnodes\nff02::2 ip6-allrouters\n" > "$HOSTS_FILE"; }
+xbox_dns_disable() { local SERVER; for SERVER in $XBOX_DNS_SERVERS; do uci -q del_list dhcp.@dnsmasq[0].server="/$XBOX_DNS_DOMAINS/$SERVER"; done; uci commit dhcp; }
+xbox_dns_enable() { local SERVER; for SERVER in $XBOX_DNS_SERVERS; do uci -q del_list dhcp.@dnsmasq[0].server="/$XBOX_DNS_DOMAINS/$SERVER"; uci add_list dhcp.@dnsmasq[0].server="/$XBOX_DNS_DOMAINS/$SERVER"; done; uci commit dhcp; }
+download_geo_hosts() { local TMP_GEO_HOSTS; TMP_GEO_HOSTS="/tmp/zapret-geohide-hosts.$$"; if ! wget -q -U "Mozilla/5.0" -O "$TMP_GEO_HOSTS" "$GEO_HOSTS" || ! grep -q "### dns.geohide.ru" "$TMP_GEO_HOSTS"; then rm -f "$TMP_GEO_HOSTS"; return 1; fi; write_default_hosts; cat "$TMP_GEO_HOSTS" >> "$HOSTS_FILE"; rm -f "$TMP_GEO_HOSTS"; }
+remove_xbox_domains_from_hosts() { sed -i -E '/^[^#].*[[:space:]]([^[:space:]]+\.)?(chatgpt\.com|openai\.com|oaistatic\.com|oaiusercontent\.com|openaimerge\.com|sora\.com|cdn\.auth0\.com)([[:space:]]|$)/d' "$HOSTS_FILE"; }
+hosts_reset() { echo -e "\n${MAGENTA}Восстанавливаем hosts${NC}"; write_default_hosts; xbox_dns_disable; /etc/init.d/dnsmasq restart >/dev/null 2>&1; echo -e "hosts ${GREEN}восстановлен!${NC}\n"; PAUSE; }
 add_block() { printf '%b\n' "$1" | while IFS= read -r line; do [ -z "$line" ] && continue; grep -Fxq "$line" "$HOSTS_FILE" || echo "$line" >> "$HOSTS_FILE"; done; }
-add_GEO_HOSTS() { echo -e "\n${MAGENTA}Заменяем hosts на GeoHide hosts${NC}"; : > /etc/hosts; echo -e "127.0.0.1\tlocalhost\n\n::1\tlocalhost ip6-localhost ip6-loopback\nff02::1 ip6-allnodes\nff02::2 ip6-allrouters" > /etc/hosts
-wget -q -U "Mozilla/5.0" -O - "$GEO_HOSTS" >> /etc/hosts; /etc/init.d/dnsmasq restart >/dev/null 2>&1; echo -e "hosts ${GREEN}заменён на ${NC}GeoHide hosts${GREEN}!${NC}\n"; PAUSE; }
+add_GEO_HOSTS() { echo -e "\n${MAGENTA}Заменяем hosts на GeoHide hosts${NC}"; if ! download_geo_hosts; then echo -e "\n${RED}Не удалось скачать GeoHide hosts${NC}\n"; PAUSE; return; fi; xbox_dns_disable; /etc/init.d/dnsmasq restart >/dev/null 2>&1; echo -e "hosts ${GREEN}заменён на ${NC}GeoHide hosts${GREEN}!${NC}\n"; PAUSE; }
+add_GEO_XBOX() { echo -e "\n${MAGENTA}Устанавливаем GeoHide hosts + Xbox DNS для OpenAI${NC}"; if ! download_geo_hosts; then echo -e "\n${RED}Не удалось скачать GeoHide hosts${NC}\n"; PAUSE; return; fi; remove_xbox_domains_from_hosts; xbox_dns_enable; /etc/init.d/dnsmasq restart >/dev/null 2>&1; echo -e "hosts ${GREEN}заменён на ${NC}GeoHide hosts${GREEN}, OpenAI использует Xbox DNS!${NC}\n"; PAUSE; }
 remove_block() { printf '%b\n' "$1" | while IFS= read -r line; do [ -z "$line" ] && continue; sed -i "\|^$line$|d" "$HOSTS_FILE"; done; }
 toggle_block() { if status_block "$1"; then remove_block "$1"; echo -e "\n${CYAN}Удаляем и применяем${NC}"; else add_block "$1"; echo -e "\n${CYAN}Добавляем и применяем${NC}"; fi; /etc/init.d/dnsmasq restart >/dev/null 2>&1; echo -e "${GREEN}Изменения применены!${NC}\n"; PAUSE; }
 toggle_all() { if status_block "$ALL_BLOCKS"; then remove_block "$ALL_BLOCKS"; echo -e "\n${CYAN}Удаляем и применяем${NC}"; else add_block "$ALL_BLOCKS"; echo -e "\n${CYAN}Добавляем и применяем${NC}"; fi; /etc/init.d/dnsmasq restart >/dev/null 2>&1; echo -e "${GREEN}Изменения применены!${NC}\n"; PAUSE; }
@@ -439,13 +446,13 @@ echo -e "${CYAN} 0) ${GREEN}$(get_state "$NALOG")${NC} nalog.ru\n${CYAN} 1) ${GR
 echo -e "${CYAN} 3) ${GREEN}$(get_state "$INSTAGRAM")${NC} Instagram & Facebook\n${CYAN} 4) ${GREEN}$(get_state "$LIBRUSEC")${NC} lib.rus.ec\n${CYAN} 5) ${GREEN}$(get_state "$AI")${NC} AI сервисы"
 echo -e "${CYAN} 6) ${GREEN}$(get_state "$TWCH")${NC} Twitch\n${CYAN} 7) ${GREEN}$(get_state "$TGWeb")${NC} Telegram Web\n${CYAN} 8) ${GREEN}$(get_state "$SPFY")${NC} Spotify\n${CYAN} 9) ${GREEN}$(get_state "$SCell")${NC} Supercell"
 echo -e "${CYAN}10) ${GREEN}$(get_state "$GITH_RAW")${NC} githubusercontent.com\n${CYAN}11) ${GREEN}$(get_state "$GITH")${NC} github.com\n${CYAN}12) $S_ALL\n${CYAN}13) ${GREEN}Заменить ${NC}hosts${GREEN} на ${NC}GeoHide hosts"
-echo -e "${CYAN}14) ${GREEN}Заменить ${NC}hosts${GREEN} на ${NC}Mafioznik hosts\n${CYAN}15) ${GREEN}Заменить ${NC}hosts${GREEN} на ${NC}Malw.link hosts\n${CYAN}16) ${GREEN}Восстановить ${NC}hosts"
+echo -e "${CYAN}14) ${GREEN}Заменить ${NC}hosts${GREEN} на ${NC}GeoHide hosts + Xbox DNS для OpenAI\n${CYAN}15) ${GREEN}Заменить ${NC}hosts${GREEN} на ${NC}Mafioznik hosts\n${CYAN}16) ${GREEN}Заменить ${NC}hosts${GREEN} на ${NC}Malw.link hosts\n${CYAN}17) ${GREEN}Восстановить ${NC}hosts"
 echo -ne "${CYAN}Enter) ${GREEN}Выход в главное меню${NC}\n\n${YELLOW}Выберите пункт:${NC} ";read -r c; case "$c" in 0) toggle_block "$NALOG";; 1) toggle_block "$RUTOR";; 2) toggle_block "$NTC";; 3) toggle_block "$INSTAGRAM";;
 4) toggle_block "$LIBRUSEC";; 5) toggle_block "$AI";; 6) toggle_block "$TWCH";; 7) toggle_block "$TGWeb";; 8) toggle_block "$SPFY";; 9) toggle_block "$SCell";; 10) toggle_block "$GITH_RAW";; 11) toggle_block "$GITH";; 12) toggle_all;;
-13) add_GEO_HOSTS;; 14) echo -e "\n${MAGENTA}Заменяем hosts на Mafioznik hosts${NC}"; wget -qO /etc/hosts https://raw.githubusercontent.com/StressOzz/Zapret-Manager/refs/heads/main/files/hosts_mafioznik.txt >/dev/null 2>&1 || { echo -e "\n${RED}Не удалось скачать файл hosts${NC}\n"; PAUSE; }
-/etc/init.d/dnsmasq restart >/dev/null 2>&1; echo -e "hosts ${GREEN}заменён на ${NC}Mafioznik hosts${GREEN}!${NC}\n"; PAUSE;; 15) echo -e "\n${MAGENTA}Заменяем hosts на Malw.link hosts${NC}"
+13) add_GEO_HOSTS;; 14) add_GEO_XBOX;; 15) echo -e "\n${MAGENTA}Заменяем hosts на Mafioznik hosts${NC}"; wget -qO /etc/hosts https://raw.githubusercontent.com/StressOzz/Zapret-Manager/refs/heads/main/files/hosts_mafioznik.txt >/dev/null 2>&1 || { echo -e "\n${RED}Не удалось скачать файл hosts${NC}\n"; PAUSE; }
+xbox_dns_disable; /etc/init.d/dnsmasq restart >/dev/null 2>&1; echo -e "hosts ${GREEN}заменён на ${NC}Mafioznik hosts${GREEN}!${NC}\n"; PAUSE;; 16) echo -e "\n${MAGENTA}Заменяем hosts на Malw.link hosts${NC}"
 wget -qO /etc/hosts https://raw.githubusercontent.com/StressOzz/Zapret-Manager/refs/heads/main/files/hosts_malw.link.txt >/dev/null 2>&1 || { echo -e "\n${RED}Не удалось скачать файл hosts${NC}\n"; PAUSE; }
-/etc/init.d/dnsmasq restart >/dev/null 2>&1; echo -e "hosts ${GREEN}заменён на ${NC}Malw.link hosts${GREEN}!${NC}\n"; PAUSE;; 16) hosts_reset;; *) break;; esac; done; }
+xbox_dns_disable; /etc/init.d/dnsmasq restart >/dev/null 2>&1; echo -e "hosts ${GREEN}заменён на ${NC}Malw.link hosts${GREEN}!${NC}\n"; PAUSE;; 17) hosts_reset;; *) break;; esac; done; }
 status_block() { local line; while IFS= read -r line; do [ -z "$line" ] && continue; grep -Fxq "$line" "$HOSTS_FILE" || return 1; done <<EOF
 $(printf '%b\n' "$1")
 EOF

--- a/readme.md
+++ b/readme.md
@@ -328,9 +328,10 @@ zms
   ├─ 11 Добавить / Удалить  github.com
   ├─ 12 Удалить все домены
   ├─ 13 Заменить hosts на GeoHide hosts
-  ├─ 14 Заменить hosts на Mafioznik hosts
-  ├─ 15 Заменить hosts на Malw.link hosts
-  ├─ 16 Восстановить hosts
+  ├─ 14 Заменить hosts на GeoHide hosts + Xbox DNS для OpenAI
+  ├─ 15 Заменить hosts на Mafioznik hosts
+  ├─ 16 Заменить hosts на Malw.link hosts
+  ├─ 17 Восстановить hosts
   └─Enter Выход в главное меню
 
 ─ 9 Удалить → установить → настроить Zapret


### PR DESCRIPTION
## Что изменено

- Добавлен пункт `14` — `GeoHide hosts + Xbox DNS для OpenAI`.
- GeoHide hosts скачивается и проверяется до замены текущего файла.
- Статические записи OpenAI удаляются из GeoHide hosts.
- Домены ChatGPT/OpenAI условно направляются через Xbox DNS `111.88.96.50` и `111.88.96.51`.
- Повторное применение не создаёт дубли UCI-правил.
- При переключении на обычный GeoHide, Mafioznik, Malw.link или восстановлении hosts правила Xbox DNS удаляются.
- Текущий смешанный режим отображается в статусе менеджера.
- Обновлено дерево меню в README.

## Зачем

GeoHide hosts содержит статические адреса прокси для OpenAI. При деградации одного из них браузер случайно попадает на медленный или недоступный узел. Xbox DNS возвращает актуальный шлюз динамически, при этом GeoHide продолжает обслуживать остальные домены.

## Проверка

- `sh -n Zapret-Manager.sh`
- `git diff --check`
- Двукратное применение пункта 14 на OpenWrt 24.10.5 без дублирования UCI-правил.
- `dnsmasq` успешно перезапущен.
- `chatgpt.com` разрешается через Xbox DNS в `87.228.47.204`.
- Пять последовательных HTTPS-проверок: примерно 0,39–0,47 секунды.
